### PR TITLE
fix akalajzi/atom-file-bookmark #16

### DIFF
--- a/lib/file-bookmark.coffee
+++ b/lib/file-bookmark.coffee
@@ -178,7 +178,8 @@ class FileBookmark
   _handleChangeActivePane: =>
     if @_getActiveEditor()?
       @disabled = no
-      @_showShortcutIcons()
+      if (atom.config.get 'file-bookmark.icons')
+         @_showShortcutIcons()
     else
       # prevent bookmarking
       @disabled = yes


### PR DESCRIPTION
Currently the plugin shows the shortcut icons unconditionally when the active pane is changed to an appropriate one. This patch fixes that behavior by inserting an extra check for the configuration option before the shortcut icons are shown. Fixes #16 